### PR TITLE
Mirror direction support

### DIFF
--- a/.github/workflows/verify-on-ubuntu.yml
+++ b/.github/workflows/verify-on-ubuntu.yml
@@ -1,13 +1,15 @@
 on: push
-name: (Ubuntu) Test the gitee mirror action
+name: Hub Action test
 jobs:
   run:
     name: Run
     runs-on: ubuntu-latest
     steps:
-    - name: Mirror the Github organization repos to Gitee.
-      uses: Yikun/gitee-mirror-action@master
+    - name: Checkout source codes
+      uses: actions/checkout@v1
+    - name: Mirror Github to Gitee
+      uses: ./.
       with:
-        private_key: ${{ secrets.GITEE_PRIVATE_KEY }}
-        github_org: kunpengcompute
-        gitee_org: kunpengcompute
+        src: github/kunpengcompute
+        dst: gitee/kunpengcompute
+        dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -1,23 +1,23 @@
-name: "Mirror the Github organization repos to Gitee."
-description: "Mirror the Github organization repos to Gitee."
+name: "Mirror Hub Action."
+description: "Mirror the organization repos between hub (github/gitee)."
 author: "yikun"
 branding:
   icon: "upload-cloud"
   color: "gray-dark"
 inputs:
-  private_key:
-    description: "private SSH key"
+  dst_key:
+    description: "The private SSH key which is used to to push code in destination hub."
     required: true
-  github_org:
-    description: "org name in Github. Such as `kunpengcompute`."
+  dst:
+    description: "Destination name. Such as `gitee/kunpengcompute`."
     required: true
-  gitee_org:
-    description: "org name in Gitee. Such as `kunpengcompute`."
+  src:
+    description: "Source name. Such as `github/kunpengcompute`."
     required: true
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
-    - ${{ inputs.private_key }}
-    - ${{ inputs.github_org }}
-    - ${{ inputs.gitee_org }}
+    - ${{ inputs.dst_key }}
+    - ${{ inputs.src }}
+    - ${{ inputs.dst }}


### PR DESCRIPTION
Now we only support mirror the Github to Gitee, we can also
support github to gitee.

Make the action more generic, looks like:
```yaml
steps:
- name: Do hub mirror operation from Github to Gitee.
  uses: Yikun/gitee-mirror-action@master
  with:
    dst_key: ${{ secrets.GITHUB_PRIVATE_KEY }}
    dst: github/kunpengcompute
    src: gitee/kunpengcompute
```

dst_key: The private SSH key which is used to to push code in
destination hub."
dst: Destination name. Such as `gitee/kunpengcompute`."
src: Source name. Such as `github/kunpengcompute`."

Close: https://github.com/Yikun/gitee-mirror-action/issues/2