### PR TITLE
Feature: Repo auto create

### DIFF
--- a/.github/workflows/verify-on-ubuntu.yml
+++ b/.github/workflows/verify-on-ubuntu.yml
@@ -13,3 +13,4 @@ jobs:
         src: github/kunpengcompute
         dst: gitee/kunpengcompute
         dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+        dst_token:  ${{ secrets.GITEE_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   dst_key:
     description: "The private SSH key which is used to to push code in destination hub."
     required: true
+  dst_token:
+    description: "The app token which is used to  create repo in destination hub."
+    required: true
   dst:
     description: "Destination name. Such as `gitee/kunpengcompute`."
     required: true
@@ -19,5 +22,6 @@ runs:
   image: "Dockerfile"
   args:
     - ${{ inputs.dst_key }}
+    - ${{ inputs.dst_token }}
     - ${{ inputs.src }}
     - ${{ inputs.dst }}


### PR DESCRIPTION
Now we only support mirror the commits and branches to destination org, but if the repo doesn't exists, will failed.

This patch adds the repo auto create support, there is a arg added:

`dst_token`, The app token which is used to  create repo in destination hub.

Close: https://github.com/Yikun/gitee-mirror-action/issues/3