### PR TITLE
Add account type support

### DIFF
--- a/.github/workflows/verify-on-ubuntu-org.yml
+++ b/.github/workflows/verify-on-ubuntu-org.yml
@@ -1,5 +1,5 @@
 on: push
-name: Hub Action test
+name: Hub Action test for org account
 jobs:
   run:
     name: Run
@@ -13,4 +13,5 @@ jobs:
         src: github/kunpengcompute
         dst: gitee/kunpengcompute
         dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
-        dst_token:  ${{ secrets.GITEE_TOKEN }}
+        dst_token: ${{ secrets.GITEE_TOKEN }}
+        account_type: org

--- a/.github/workflows/verify-on-ubuntu-user.yml
+++ b/.github/workflows/verify-on-ubuntu-user.yml
@@ -1,0 +1,16 @@
+on: push
+name: Hub Action test for user account
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source codes
+      uses: actions/checkout@v1
+    - name: Mirror Github to Gitee
+      uses: ./.
+      with:
+        src: github/Yikun
+        dst: gitee/yikunkero
+        dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+        dst_token:  ${{ secrets.GITEE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ steps:
     dst: gitee/kunpengcompute
     dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
     dst_token:  ${{ secrets.GITEE_TOKEN }}
+    account_type: org
 ```
 
 As above, the action will do mirror update from github/kunpengcompute to gitee/kunpengcompute.

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   src:
     description: "Source name. Such as `github/kunpengcompute`."
     required: true
+  account_type:
+    description: "The account type. Such as org, user."
+    default: 'user'
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -25,3 +28,4 @@ runs:
     - ${{ inputs.dst_token }}
     - ${{ inputs.src }}
     - ${{ inputs.dst }}
+    - ${{ inputs.account_type }}


### PR DESCRIPTION
This patch try to add the account type support.

The account_type can be set to "org" or "user".

Closes: #8
Related: #7