### PR TITLE
Add cache path

### DIFF
--- a/.github/workflows/verify-on-ubuntu-org.yml
+++ b/.github/workflows/verify-on-ubuntu-org.yml
@@ -1,5 +1,5 @@
 on: push
-name: Hub Action test for org account
+name: Tests / test-org-mirror
 jobs:
   run:
     name: Run

--- a/.github/workflows/verify-on-ubuntu-user-cache.yml
+++ b/.github/workflows/verify-on-ubuntu-user-cache.yml
@@ -1,0 +1,33 @@
+on: push
+name: Tests / test-user-mirror (cached)
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v1
+
+    - name: Cache src repos
+      uses: actions/cache@v1
+      id: cache
+      with:
+        path: /home/runner/work/hub-mirror-action/hub-mirror-action/hub-mirror-cache
+        key: ${{ runner.os }}-yikun-repos-cache
+
+    - name: Print the cache status
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: echo "Cached successfully."
+
+    - name: Mirror Github to Gitee
+      uses: ./.
+      with:
+        src: github/Yikun
+        dst: gitee/yikunkero
+        dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+        dst_token:  ${{ secrets.GITEE_TOKEN }}
+        cache_path: /github/workspace/hub-mirror-cache
+
+    - name: Print cache path
+      run: |
+        ls -la /home/runner/work/hub-mirror-action/hub-mirror-action/hub-mirror-cache

--- a/.github/workflows/verify-on-ubuntu-user.yml
+++ b/.github/workflows/verify-on-ubuntu-user.yml
@@ -1,5 +1,5 @@
 on: push
-name: Hub Action test for user account
+name: Tests / test-user-mirror
 jobs:
   run:
     name: Run

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   clone_style:
     description: "The git clone style, https or ssh."
     default: 'https'
+  cache_path:
+    description: "The path to cache the source repos code."
+    default: '/github/workspace/hub-mirror-cache'
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -33,3 +36,4 @@ runs:
     - ${{ inputs.dst }}
     - ${{ inputs.account_type }}
     - ${{ inputs.clone_style }}
+    - ${{ inputs.cache_path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,8 @@ DST_ACCOUNT=`basename $DST_HUB`
 
 CLONE_STYLE="${INPUT_CLONE_STYLE}"
 
+CACHE_PATH="${INPUT_CACHE_PATH}"
+
 if [[ "$ACCOUNT_TYPE" == "org" ]]; then
   SRC_LIST_URL_SUFFIX=orgs/$SRC_ACCOUNT/repos
   DST_LIST_URL_SUFFIX=orgs/$DST_ACCOUNT/repos
@@ -101,6 +103,11 @@ function import_repo
   git remote set-head origin -d
   git push $DST_TYPE refs/remotes/origin/*:refs/heads/* --tags --prune
 }
+
+if [ ! -d "$CACHE_PATH" ]; then
+  mkdir -p $CACHE_PATH
+fi
+cd $CACHE_PATH
 
 for repo in $SRC_REPOS
 {


### PR DESCRIPTION
Add a `cache_path` feature to allow user set the secific cache_path to cache the git repo.

And user can use it to set the cache path,  coordinate with  [action/cache](https://github.com/actions/cache) to speed up the mirror.

Closes: #13