### PR TITLE
Add black and white list support

### DIFF
--- a/.github/workflows/verify-on-ubuntu-org.yml
+++ b/.github/workflows/verify-on-ubuntu-org.yml
@@ -15,3 +15,6 @@ jobs:
         dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
         dst_token: ${{ secrets.GITEE_TOKEN }}
         account_type: org
+        # Only sync Kunpeng
+        black_list: 'KAE'
+        white_list: 'KAE,Kunpeng'

--- a/.github/workflows/verify-on-ubuntu-user-cache.yml
+++ b/.github/workflows/verify-on-ubuntu-user-cache.yml
@@ -19,7 +19,7 @@ jobs:
       if: steps.cache.outputs.cache-hit == 'true'
       run: echo "Cached successfully."
 
-    - name: Mirror Github to Gitee
+    - name: Mirror Github to Gitee with white list and cache
       uses: ./.
       with:
         src: github/Yikun
@@ -27,6 +27,7 @@ jobs:
         dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
         dst_token:  ${{ secrets.GITEE_TOKEN }}
         cache_path: /github/workspace/hub-mirror-cache
+        white_list: 'hub-mirror-action, hexo-migrator-github-issue'
 
     - name: Print cache path
       run: |

--- a/.github/workflows/verify-on-ubuntu-user.yml
+++ b/.github/workflows/verify-on-ubuntu-user.yml
@@ -7,10 +7,11 @@ jobs:
     steps:
     - name: Checkout source codes
       uses: actions/checkout@v1
-    - name: Mirror Github to Gitee
+    - name: Mirror Github to Gitee with white list
       uses: ./.
       with:
         src: github/Yikun
         dst: gitee/yikunkero
         dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
         dst_token:  ${{ secrets.GITEE_TOKEN }}
+        white_list: 'hub-mirror-action'

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,12 @@ inputs:
   cache_path:
     description: "The path to cache the source repos code."
     default: '/github/workspace/hub-mirror-cache'
+  black_list:
+    description: "Hight priority, the back list of mirror repo. like 'repo1,repo2,repo3'"
+    default: ''
+  white_list:
+    description: "Low priority, the white list of mirror repo. like 'repo1,repo2,repo3'"
+    default: ''
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -37,3 +43,5 @@ runs:
     - ${{ inputs.account_type }}
     - ${{ inputs.clone_style }}
     - ${{ inputs.cache_path }}
+    - ${{ inputs.black_list }}
+    - ${{ inputs.white_list }}


### PR DESCRIPTION
This patch adds the black and white list support for hub mirror action.

The back list has **high priority**, that mean if the repo in the back list will never mirror, even the repo is also in the white list.

And the white list can be used as single repo mirror, you can set white_list as specific repo to only sync this single repo.

Closes: #19, #14
Related: #18