### PR TITLE
Add force_update support

### DIFF
--- a/.github/workflows/verify-on-ubuntu-org.yml
+++ b/.github/workflows/verify-on-ubuntu-org.yml
@@ -17,4 +17,5 @@ jobs:
         account_type: org
         # Only sync Kunpeng
         black_list: 'KAE'
-        white_list: 'KAE,Kunpeng'
+        white_list: 'KAE,Kunpeng,kunpengcompute.github.io'
+        force_update: true

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can see more real workflows in [here](https://github.com/Yikun/hub-mirror-ac
 - `black_list` (optional) the black list, such as “repo1,repo2,repo3”.
 - `white_list` (optional) the white list, such as “repo1,repo2,repo3”.
 - `static_list` (optional) Only mirror repos in the static list, but don't get list from repo api dynamically (the white/black list is still available). like 'repo1,repo2,repo3'
+- `force_update` (optional) Force to update the destination repo, use '-f' flag do 'git push'
 
 ## Scenarios
 
@@ -95,6 +96,18 @@ You can see more real workflows in [here](https://github.com/Yikun/hub-mirror-ac
     dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
     dst_token: ${{ secrets.GITEE_TOKEN }}
     cache_path: /github/workspace/hub-mirror-cache
+```
+
+#### Force udpate
+```yaml
+- name: Mirror with force push (git push -f)
+  uses: Yikun/hub-mirror-action@master
+  with:
+    src: github/Yikun
+    dst: gitee/yikunkero
+    dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+    dst_token: ${{ secrets.GITEE_TOKEN }}
+    force_update: true
 ```
 
 ## FAQ

--- a/README_CN.md
+++ b/README_CN.md
@@ -95,6 +95,18 @@ steps:
     cache_path: /github/workspace/hub-mirror-cache
 ```
 
+#### 强制更新
+```yaml
+- name: Mirror with force push (git push -f)
+  uses: Yikun/hub-mirror-action@master
+  with:
+    src: github/Yikun
+    dst: gitee/yikunkero
+    dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+    dst_token: ${{ secrets.GITEE_TOKEN }}
+    force_update: true
+```
+
 ## FAQ
 
 - 如何在secrets添加dst_token和dst_key？

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
   static_list:
     description: "Only mirror repo in the static list, but don't get from repo api (the white/black list is still available). like 'repo1,repo2,repo3'"
     default: ''
+  force_update:
+    description: "Force to update the destination repo, use '-f' flag do 'git push'"
+    default: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -49,3 +52,4 @@ runs:
     - ${{ inputs.black_list }}
     - ${{ inputs.white_list }}
     - ${{ inputs.static_list }}
+    - ${{ inputs.force_update}}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,8 @@ WHITE_LIST="${INPUT_WHITE_LIST}"
 BLACK_LIST="${INPUT_BLACK_LIST}"
 STATIC_LIST="${INPUT_STATIC_LIST}"
 
+FORCE_UPDATE="${INPUT_FORCE_UPDATE}"
+
 if [[ "$ACCOUNT_TYPE" == "org" ]]; then
   SRC_LIST_URL_SUFFIX=orgs/$SRC_ACCOUNT/repos
   DST_LIST_URL_SUFFIX=orgs/$DST_ACCOUNT/repos
@@ -109,7 +111,11 @@ function import_repo
 {
   echo -e "\033[31m(2/3)\033[0m" "Importing..."
   git remote set-head origin -d
-  git push $DST_TYPE refs/remotes/origin/*:refs/heads/* --tags --prune
+  if [[ "$FORCE_UPDATE" == "true" ]]; then
+    git push -f $DST_TYPE refs/remotes/origin/*:refs/heads/* --tags --prune
+  else
+    git push $DST_TYPE refs/remotes/origin/*:refs/heads/* --tags --prune
+  fi
 }
 
 function _check_in_list () {


### PR DESCRIPTION
This patch adds the `force_update` support, the user can use it to force update the destination repo, that means the action will use '-f' flag do 'git push'.

Here is an force update exmaple:
```yaml
- name: Mirror with force push (git push -f)
  uses: Yikun/hub-mirror-action@master
  with:
    src: github/Yikun
    dst: gitee/yikunkero
    dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
    dst_token: ${{ secrets.GITEE_TOKEN }}
    force_update: true
```

Closes: https://github.com/Yikun/hub-mirror-action/issues/27