### PR TITLE
Doc: fix wrong key name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can see more real workflows in [here](https://github.com/Yikun/hub-mirror-ac
     dst: gitee/yikunkero
     dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
     dst_token: ${{ secrets.GITEE_TOKEN }}
-    white_list: "hub-mirror-action,hashes"
+    black_list: "hub-mirror-action,hashes"
 ```
 
 #### clone style, use `ssh` clone style

--- a/README_CN.md
+++ b/README_CN.md
@@ -68,7 +68,7 @@ steps:
     dst: gitee/yikunkero
     dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
     dst_token: ${{ secrets.GITEE_TOKEN }}
-    white_list: "hub-mirror-action,hashes"
+    black_list: "hub-mirror-action,hashes"
 ```
 
 #### clone方式，使用ssh方式进行clone


### PR DESCRIPTION
Change "white_list" to "black_list"

Closes: https://github.com/Yikun/hub-mirror-action/issues/31