### PR TITLE
Make empty repo sync work

### DIFF
--- a/.github/workflows/verify-on-ubuntu-org.yml
+++ b/.github/workflows/verify-on-ubuntu-org.yml
@@ -17,6 +17,6 @@ jobs:
         account_type: org
         # Only sync normal repo
         black_list: 'test'
-        white_list: 'normal,test'
+        white_list: 'normal,test,empty'
         force_update: true
         debug: true

--- a/hub-mirror/mirror.py
+++ b/hub-mirror/mirror.py
@@ -57,9 +57,19 @@ class Mirror(object):
         print("(2/3) Creating...")
         self.hub.create_dst_repo(self.name)
 
+    def _check_empty(self, repo):
+        cmd = ["-n", "1", "--all"]
+        if repo.git.rev_list(*cmd):
+            return False
+        else:
+            return True
+
     @retry(wait=wait_exponential(), reraise=True, stop=stop_after_attempt(3))
     def push(self, force=False):
         local_repo = git.Repo(self.repo_path)
+        if self._check_empty(local_repo):
+            print("Empty repo %s, skip pushing." % self.src_url)
+            return
         cmd = ['set-head', 'origin', '-d']
         local_repo.git.remote(*cmd)
         try:


### PR DESCRIPTION
If the repo is empty, the repo pushing will be skipped, that means, only empty repo will be created, and keep it empty like source repo.

Close: https://github.com/Yikun/hub-mirror-action/issues/62