### PR TITLE
fix static_list without strip space

### DIFF
--- a/.github/workflows/verify-on-ubuntu-user.yml
+++ b/.github/workflows/verify-on-ubuntu-user.yml
@@ -14,6 +14,6 @@ jobs:
         dst: gitee/yikunkero
         dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
         dst_token:  ${{ secrets.GITEE_TOKEN }}
-        static_list: 'hub-mirror-action,hashes,simple-spring'
+        static_list: 'hub-mirror-action,hashes, simple-spring'
         force_update: true
         debug: true

--- a/hub-mirror/hubmirror.py
+++ b/hub-mirror/hubmirror.py
@@ -59,8 +59,8 @@ class HubMirror(object):
         src_type, src_account = self.args.src.split('/')
 
         # Using static list when static_list is set
-        repos = self.args.static_list
-        src_repos = repos.split(',') if repos else hub.dynamic_list()
+        repos = self.static_list
+        src_repos = repos if repos else hub.dynamic_list()
 
         total, success, skip = len(src_repos), 0, 0
         failed_list = []


### PR DESCRIPTION
If there are spaces in the static_list, the generated git clone url will also have spaces and the clone task will fail.