### PR TITLE
Add dst_visibility support

### DIFF
--- a/.github/workflows/verify-on-ubuntu-private.yml
+++ b/.github/workflows/verify-on-ubuntu-private.yml
@@ -1,0 +1,23 @@
+on:
+  pull_request_target:
+    branches: [master]
+name: Tests / test-user-mirror
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source codes
+      uses: actions/checkout@v1
+    - name: Mirror Github to Gitee with white list
+      uses: ./.
+      with:
+        src: github/Yikun
+        dst: gitee/yikunkero
+        dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+        dst_token:  ${{ secrets.GITEE_TOKEN }}
+        static_list: 'hashes,simple-spring'
+        force_update: true
+        debug: true
+        mappings: 'hashes=>private_hashes,simple-spring=>private_simple-spring'
+        dst_visibility: 'private'

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# uv
+uv.lock
+
 # Spyder project settings
 .spyderproject
 .spyproject
@@ -128,3 +131,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+pyproject.toml

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ steps:
 - `lfs` 提供[git lfs](https://git-lfs.com/)支持, 默认为false, 配置为true后，调用`git lfs fetch --all`和`git lfs push --all`进行同步。
 - `api_timeout`（可选）默认值为 `60`，用于设置 API 请求的超时时间（单位：秒）。
   例如：`api_timeout: '90'`
+- `dst_visibility` （可选） 默认为`auto`。该参数代表味着同步目标仓库的默认的设置为状态。`auto`代表只会同步，将不进行任何修改。`public`代表将目标仓库设置为公开仓库，`private`代表将目标仓库设置为私有仓库。
 
 ## 举些例子
 

--- a/README_en.md
+++ b/README_en.md
@@ -58,6 +58,7 @@ More than [100+](https://github.com/search?p=2&q=hub-mirror-action+%22account_ty
 - `lfs` (optional) Default is false, support [git lfs](https://git-lfs.com/), call `git lfs fetch --all` and `git lfs push --all` to support lfs mirror.
 - `api_timeout` (optional) Default is `60`, sets the timeout for API requests (in seconds). 
   Example usage: `api_timeout: '90'`
+- `dst_visibility` (optional) Default is `auto`. This parameter represents the default setting of the destination repository's visibility during synchronization. `auto` means only synchronization will be performed without any modifications. `public` means setting the destination repository to public, and `private` means setting it to private.
 
 ## Scenarios
 

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,9 @@ inputs:
   lfs:
     description: "Enable Git LFS support."
     default: false
+  dst_visibility:
+    description: "Set destination repo visibility to public, private, or auto (preserve destination visibility)."
+    default: 'auto'
 runs:
   using: "composite"
   steps:
@@ -158,5 +161,6 @@ runs:
           --timeout "${{ inputs.timeout }}" \
           --api-timeout "${{ inputs.api_timeout }}" \
           --mappings "${{ inputs.mappings }}" \
-          --lfs "${{ inputs.lfs }}"
+          --lfs "${{ inputs.lfs }}" \
+          --dst-visibility "${{ inputs.dst_visibility }}" \
       shell: bash

--- a/hub-mirror/hub.py
+++ b/hub-mirror/hub.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 import requests
 
-from platforms import GitPlatform, get_platform
+from platforms import GitPlatform, RepoVisibility, get_platform
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +23,13 @@ class Hub(object):
         src_endpoint: str = "",
         dst_endpoint: str = "",
         api_timeout: int = 60,
+        dst_visibility: RepoVisibility = RepoVisibility.AUTO,
     ) -> None:
         self.api_timeout: int = api_timeout
         self.account_type: str = account_type
         self.src_account_type: str = src_account_type or account_type
         self.dst_account_type: str = dst_account_type or account_type
+        self.dst_visibility: RepoVisibility = dst_visibility
         self.src_type, self.src_account = src.split("/")
         self.dst_type, self.dst_account = dst.split("/")
         self.src_platform: GitPlatform = get_platform(
@@ -84,6 +86,16 @@ class Hub(object):
             self.src_account, self.src_account_type
         )
         return self._get_all_repo_names(url)
+
+    def update_dst_repo_visibility(self, repo_name: str) -> bool:
+        return self.dst_platform.update_repo_visibility(
+            self.session,
+            self.dst_account,
+            repo_name,
+            self.dst_visibility,
+            self.dst_token,
+            self.api_timeout,
+        )
 
     @functools.lru_cache
     def _get_all_repo_names(self, url: str, page: int = 1) -> List[str]:

--- a/hub-mirror/hubmirror.py
+++ b/hub-mirror/hubmirror.py
@@ -7,6 +7,7 @@ import click
 
 from hub import Hub
 from mirror import Mirror
+from platforms import ALLOWED_VISIBILITY, RepoVisibility
 from utils import str2list, str2map
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class MirrorConfig:
     api_timeout: int = 60
     mappings: str = ""
     lfs: bool = False
+    dst_visibility: RepoVisibility = RepoVisibility.AUTO
 
 
 class HubMirror(object):
@@ -67,6 +69,7 @@ class HubMirror(object):
             src_endpoint=config.src_endpoint,
             dst_endpoint=config.dst_endpoint,
             api_timeout=config.api_timeout,
+            dst_visibility=config.dst_visibility,
         )
 
         # Using static list when static_list is set
@@ -96,6 +99,10 @@ class HubMirror(object):
                     mirror.download()
                     mirror.create()
                     mirror.push()
+                    if not hub.update_dst_repo_visibility(dst_repo):
+                        raise RuntimeError(
+                            f"Failed to update repo visibility for {dst_repo}"
+                        )
                     success += 1
                 except Exception as e:
                     logger.error(f"Mirror failed for {src_repo}: {e}")
@@ -164,6 +171,13 @@ CLI_OPTIONS = [
     click.option("--api-timeout", default=60, type=int, show_default=True),
     click.option("--mappings", default="", show_default=True),
     click.option("--lfs", default=False, type=click.BOOL, show_default=True),
+    click.option(
+        "--dst-visibility",
+        default="auto",
+        type=click.Choice(ALLOWED_VISIBILITY, case_sensitive=False),
+        show_default=True,
+        help="Set destination repo visibility (public, private, or auto).",
+    ),
 ]
 
 
@@ -204,6 +218,9 @@ def main(**params: Any) -> None:
         level=log_level,
     )
     params["debug"] = logging.getLevelName(log_level)
+    params["dst_visibility"] = RepoVisibility.from_str(
+        params["dst_visibility"]
+    )
     config = MirrorConfig(**params)
     mirror = HubMirror(config)
     mirror.run()

--- a/hub-mirror/platforms.py
+++ b/hub-mirror/platforms.py
@@ -1,11 +1,33 @@
 import json
 import logging
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Type
 
 import requests
 
 logger = logging.getLogger(__name__)
+
+ALLOWED_VISIBILITY = ("auto", "public", "private")
+
+
+class RepoVisibility(str, Enum):
+    AUTO = "auto"
+    PUBLIC = "public"
+    PRIVATE = "private"
+
+    @classmethod
+    def from_str(cls, value: Any) -> "RepoVisibility":
+        if isinstance(value, RepoVisibility):
+            return value
+        normalized = str(value).strip().lower()
+        try:
+            return cls(normalized)
+        except ValueError as exc:
+            allowed = ", ".join(ALLOWED_VISIBILITY)
+            raise ValueError(
+                f"Invalid visibility '{value}'. Must be one of: {allowed}."
+            ) from exc
 
 
 class GitPlatform(ABC):
@@ -54,6 +76,18 @@ class GitPlatform(ABC):
     ) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
+    def update_repo_visibility(
+        self,
+        session: requests.Session,
+        account: str,
+        repo_name: str,
+        visibility: RepoVisibility,
+        token: str,
+        api_timeout: int,
+    ) -> bool:
+        raise NotImplementedError
+
 
 class GitHubPlatform(GitPlatform):
     name = "github"
@@ -90,6 +124,49 @@ class GitHubPlatform(GitPlatform):
             logger.info("Destination repo creating accepted.")
             return True
         logger.error(f"Destination repo creating failed: {response.text}")
+        return False
+
+    def update_repo_visibility(
+        self,
+        session: requests.Session,
+        account: str,
+        repo_name: str,
+        visibility: RepoVisibility,
+        token: str,
+        api_timeout: int,
+    ) -> bool:
+        """Update repository visibility for GitHub.
+
+        Endpoint: PATCH https://api.github.com/repos/{owner}/{repo}
+        Docs: https://docs.github.com/en/rest/repos/repos#update-a-repository
+        """
+        try:
+            visibility_enum = RepoVisibility.from_str(visibility)
+        except ValueError as exc:
+            logger.error(str(exc))
+            return False
+
+        if visibility_enum == RepoVisibility.AUTO:
+            return True
+
+        logger.info(
+            f"Updating repo visibility to {visibility_enum.value}..."
+        )
+        url: str = f"{self.api_base}/repos/{account}/{repo_name}"
+        response: requests.Response = session.patch(
+            url,
+            headers={
+                "Authorization": "token " + token,
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            json={"private": visibility_enum == RepoVisibility.PRIVATE},
+            timeout=api_timeout,
+        )
+        if response.status_code == 200:
+            logger.info("Repo visibility updated.")
+            return True
+        logger.error(f"Repo visibility update failed: {response.text}")
         return False
 
 
@@ -129,6 +206,47 @@ class GiteePlatform(GitPlatform):
         logger.error(f"Destination repo creating failed: {response.text}")
         return False
 
+    def update_repo_visibility(
+        self,
+        session: requests.Session,
+        account: str,
+        repo_name: str,
+        visibility: RepoVisibility,
+        token: str,
+        api_timeout: int,
+    ) -> bool:
+        """Update repository visibility for Gitee.
+
+        Docs: https://gitee.com/api/v5/swagger
+        """
+        try:
+            visibility_enum = RepoVisibility.from_str(visibility)
+        except ValueError as exc:
+            logger.error(str(exc))
+            return False
+
+        if visibility_enum == RepoVisibility.AUTO:
+            return True
+
+        logger.info(f"Updating repo visibility to {visibility_enum.value}...")
+        url: str = f"{self.api_base}/repos/{account}/{repo_name}"
+        is_private: bool = visibility_enum == RepoVisibility.PRIVATE
+        response: requests.Response = session.patch(
+            url,
+            headers={"Content-Type": "application/json;charset=UTF-8"},
+            params={
+                "access_token": token,
+                "name": repo_name,
+                "private": is_private,
+            },
+            timeout=api_timeout,
+        )
+        if response.status_code == 200:
+            logger.info("Repo visibility updated.")
+            return True
+        logger.error(f"Repo visibility update failed: {response.text}")
+        return False
+
 
 class GitcodePlatform(GitPlatform):
     name = "gitcode"
@@ -165,6 +283,49 @@ class GitcodePlatform(GitPlatform):
             logger.info("Destination repo creating accepted.")
             return True
         logger.error(f"Destination repo creating failed: {response.text}")
+        return False
+
+    def update_repo_visibility(
+        self,
+        session: requests.Session,
+        account: str,
+        repo_name: str,
+        visibility: RepoVisibility,
+        token: str,
+        api_timeout: int,
+    ) -> bool:
+        """Update repository visibility for GitCode.
+
+        Endpoint: PATCH https://api.gitcode.com/api/v5/repos/{owner}/{repo}
+        Docs: https://docs.gitcode.com/en/docs/repos/
+        """
+        try:
+            visibility_enum = RepoVisibility.from_str(visibility)
+        except ValueError as exc:
+            logger.error(str(exc))
+            return False
+
+        if visibility_enum == RepoVisibility.AUTO:
+            return True
+
+        logger.info(
+            f"Updating repo visibility to {visibility_enum.value}..."
+        )
+        url: str = f"{self.api_base}/repos/{account}/{repo_name}"
+        response: requests.Response = session.patch(
+            url,
+            headers={"Content-Type": "application/json;charset=UTF-8"},
+            params={"access_token": token},
+            json={
+                "name": repo_name,
+                "private": visibility_enum == RepoVisibility.PRIVATE,
+            },
+            timeout=api_timeout,
+        )
+        if response.status_code == 200:
+            logger.info("Repo visibility updated.")
+            return True
+        logger.error(f"Repo visibility update failed: {response.text}")
         return False
 
 
@@ -237,6 +398,48 @@ class GitLabPlatform(GitPlatform):
             logger.error("Failed to get groups list.")
             logger.error(f"Error message: {response.text}")
         return None
+
+    def update_repo_visibility(
+        self,
+        session: requests.Session,
+        account: str,
+        repo_name: str,
+        visibility: RepoVisibility,
+        token: str,
+        api_timeout: int,
+    ) -> bool:
+        """Update repository visibility for GitLab.
+
+        Endpoint: PUT https://{host}/api/v4/projects/:id
+        Docs: https://docs.gitlab.com/api/projects/#edit-a-project
+        """
+        try:
+            visibility_enum = RepoVisibility.from_str(visibility)
+        except ValueError as exc:
+            logger.error(str(exc))
+            return False
+
+        if visibility_enum == RepoVisibility.AUTO:
+            return True
+
+        logger.info(
+            f"Updating repo visibility to {visibility_enum.value}..."
+        )
+        project_path = f"{account}/{repo_name}"
+        encoded_project = requests.utils.quote(project_path, safe="")
+        url: str = f"{self.api_base}/projects/{encoded_project}"
+        headers: Dict[str, str] = {"PRIVATE-TOKEN": token}
+        response: requests.Response = session.put(
+            url,
+            data={"visibility": visibility_enum.value},
+            headers=headers,
+            timeout=api_timeout,
+        )
+        if response.status_code == 200:
+            logger.info("Repo visibility updated.")
+            return True
+        logger.error(f"Repo visibility update failed: {response.text}")
+        return False
 
 
 def get_platform(name: str, endpoint: str = "") -> GitPlatform:


### PR DESCRIPTION
Due some [well known issue of gitee repo policy](https://www.infoq.cn/article/2ttlpz58wfskk852f04d), we have to add a friendly parameter to support mirror the repo as `private` repo.

Take below yaml as example:
```yaml
- name: Mirror the Github organization repos to Gitee.
  uses: Yikun/hub-mirror-action@master
  with:
    src: github/Yikun
    dst: gitee/yikunkero
    dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
    dst_token:  ${{ secrets.GITEE_TOKEN }}
    force_update: true
    debug: true
    # mirror hashes and simple-spring repo
    static_list: 'hashes,simple-spring'
    # these repos will be mirrored as private repo
    dst_visibility: 'private'
```

This will help to create mirror as private repo.

Close:
- https://github.com/Yikun/hub-mirror-action/issues/159
- https://github.com/Yikun/hub-mirror-action/issues/155

Related: https://github.com/Yikun/hub-mirror-action/issues/38

CO-AUTHORED-BY: @dislazy