### PR TITLE
Upgrade PyYAML to 6.x to fix CI broken

### DIFF
--- a/hub-mirror/requirements.txt
+++ b/hub-mirror/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==5.4.1
+PyYAML>=6.0.1
 GitPython==3.1.13
 requests==2.25.1
 tenacity==6.3.1


### PR DESCRIPTION
Closes: https://github.com/Yikun/hub-mirror-action/issues/181