### PR TITLE
Use venv to resolve `error: externally-managed-environment`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 
-RUN apt update && apt install git git-lfs python3 python3-pip -y && \
+RUN apt update && apt install git git-lfs python3-full python3-pip -y && \
   echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 ADD *.sh /

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,9 +10,7 @@ mkdir -p /root/.ssh
 echo "${INPUT_DST_KEY}" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 
-rm -rf /github/home/.cache/pip
-mikdir /github/home/.cache/pip
-chmod 600 /github/home/.cache/pip
+python -m pip install --upgrade pip
 
 pip3 install -r /hub-mirror/requirements.txt
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ mkdir -p /root/.ssh
 echo "${INPUT_DST_KEY}" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 
-pip3 install -H -r /hub-mirror/requirements.txt
+sudo -H pip3 install -r /hub-mirror/requirements.txt
 
 git lfs install
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,6 @@ mkdir -p /root/.ssh
 echo "${INPUT_DST_KEY}" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 
-python -m pip install --upgrade pip
-
 pip3 install -r /hub-mirror/requirements.txt
 
 git lfs install

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ mkdir -p /root/.ssh
 echo "${INPUT_DST_KEY}" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 
-pip3 install -r /hub-mirror/requirements.txt
+pip3 install -H -r /hub-mirror/requirements.txt
 
 git lfs install
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,10 @@ fi
 mkdir -p /root/.ssh
 echo "${INPUT_DST_KEY}" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
-chmod -R /github/home/.cache/pip
+
+rm -rf /github/home/.cache/pip
+mikdir /github/home/.cache/pip
+chmod 600 /github/home/.cache/pip
 
 pip3 install -r /hub-mirror/requirements.txt
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ echo "${INPUT_DST_KEY}" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 
 python3 -m venv /hub-mirror/venv
+source /hub-mirror/venv/bin/activate
 pip3 install -r /hub-mirror/requirements.txt
 
 git lfs install

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ mkdir -p /root/.ssh
 echo "${INPUT_DST_KEY}" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 
+python3 -m venv /hub-mirror/venv
 pip3 install -r /hub-mirror/requirements.txt
 
 git lfs install

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,9 @@ fi
 mkdir -p /root/.ssh
 echo "${INPUT_DST_KEY}" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
+chmod -R /github/home/.cache/pip
 
-sudo -H pip3 install -r /hub-mirror/requirements.txt
+pip3 install -r /hub-mirror/requirements.txt
 
 git lfs install
 


### PR DESCRIPTION
This patch try to resolve `externally-managed-environment` error by using separate venv.

```
error: externally-managed-environment
﻿
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
python3-xyz, where xyz is the package you are trying to
install.
    
If you wish to install a non-Debian-packaged Python package,
create a virtual environment using python3 -m venv path/to/venv.
Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
sure you have python3-full installed.
```

See also:
- https://stackoverflow.com/questions/75608323/how-do-i-solve-error-externally-managed-environment-every-time-i-use-pip-3
- https://peps.python.org/pep-0668/