### PR TITLE
Add API Timeout Configuration & Fix Repo Existence Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ steps:
 - `timeout` 默认为'30m', 用于设置每个git命令的超时时间，'600'=>600s, '30m'=>30 mins, '1h'=>1 hours
 - `mappings` 源仓库映射规则，比如'A=>B, C=>CC', A会被映射为B，C会映射为CC，映射不具有传递性。主要用于源和目的仓库名不同的镜像。
 - `lfs` 提供[git lfs](https://git-lfs.com/)支持, 默认为false, 配置为true后，调用`git lfs fetch --all`和`git lfs push --all`进行同步。
+- `api_timeout`（可选）默认值为 `60`，用于设置 API 请求的超时时间（单位：秒）。
+  例如：`api_timeout: '90'`
 
 ## 举些例子
 

--- a/README_en.md
+++ b/README_en.md
@@ -64,6 +64,8 @@ More than [100+](https://github.com/search?p=2&q=hub-mirror-action+%22account_ty
 - `timeout` (optional) Default is '30m', set the timeout for every git command, like '600'=>600s, '30m'=>30 mins, '1h'=>1 hours
 - `mappings` (optional) Default is empty, the source repos mappings, such as 'A=>B, C=>CC', source repo name would be mapped follow the rule: A to B, C to CC. Mapping is not transitive.
 - `lfs` (optional) Default is false, support [git lfs](https://git-lfs.com/), call `git lfs fetch --all` and `git lfs push --all` to support lfs mirror.
+- `api_timeout` (optional) Default is `60`, sets the timeout for API requests (in seconds). 
+  Example usage: `api_timeout: '90'`
 
 ## Scenarios
 

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,9 @@ inputs:
   timeout:
     description: "Set the timeout for every git command, like '600'=>600s, '30m'=>30 mins, '1h'=>1 hours"
     default: '30m'
+  api_timeout:
+    description: "Set the timeout for API requests (in seconds)."
+    default: '60'
   mappings:
     description: "The source repos mappings, such as 'A=>B, C=>CC', source repo name would be mapped follow the rule: A to B, C to CC. Mapping is not transitive."
     default: ''
@@ -75,5 +78,6 @@ runs:
     - ${{ inputs.force_update}}
     - ${{ inputs.debug}}
     - ${{ inputs.timeout}}
+    - ${{ inputs.api_timeout }}
     - ${{ inputs.mappings}}
     - ${{ inputs.lfs }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,7 @@ python3 /hub-mirror/hubmirror.py --src "${INPUT_SRC}" --dst "${INPUT_DST}" \
 --force-update "${INPUT_FORCE_UPDATE}" \
 --debug "${INPUT_DEBUG}" \
 --timeout  "${INPUT_TIMEOUT}" \
+--api-timeout "${INPUT_API_TIMEOUT}" \
 --mappings  "${INPUT_MAPPINGS}" \
 --lfs "${INPUT_LFS}"
 

--- a/hub-mirror/hub.py
+++ b/hub-mirror/hub.py
@@ -86,6 +86,7 @@ class Hub(object):
         return repo_name in repo_names
 
     def create_dst_repo(self, repo_name):
+        result = None
         # gitlab ---> projects, github/gitee ---> repos
         repo_field = "projects" if self.dst_type == "gitlab" else "repos"
         if self.dst_type == "gitlab":
@@ -103,7 +104,6 @@ class Hub(object):
             url = '/'.join(
                 [self.dst_base, suffix]
             )
-            result = None
             if self.dst_type == 'gitee':
                 data = {'name': repo_name}
             elif self.dst_type == 'github':

--- a/hub-mirror/hub.py
+++ b/hub-mirror/hub.py
@@ -11,7 +11,9 @@ class Hub(object):
         clone_style="https",
         src_account_type=None,
         dst_account_type=None,
+        api_timeout=60,
     ):
+        self.api_timeout = api_timeout
         self.account_type = account_type
         self.src_account_type = src_account_type or account_type
         self.dst_account_type = dst_account_type or account_type
@@ -112,7 +114,8 @@ class Hub(object):
                 response = self.session.post(
                     url,
                     data=data,
-                    headers={'Authorization': 'token ' + self.dst_token}
+                    headers={'Authorization': 'token ' + self.dst_token},
+                    timeout=self.api_timeout
                 )
                 result = response.status_code == 201
                 if result:
@@ -123,7 +126,8 @@ class Hub(object):
                 response = requests.post(
                     url,
                     headers={'Content-Type': 'application/json;charset=UTF-8'},
-                    params={"name": repo_name, "access_token": self.dst_token}
+                    params={"name": repo_name, "access_token": self.dst_token},
+                    timeout=self.api_timeout
                 )
                 result = response.status_code == 201
                 if result:
@@ -134,7 +138,8 @@ class Hub(object):
                 response = self.session.post(
                     url,
                     data=data,
-                    headers=headers
+                    headers=headers,
+                    timeout=self.api_timeout
                 )
                 result = response.status_code == 201
                 if result:
@@ -164,7 +169,7 @@ class Hub(object):
         per_page = 60
         api = url + f"?page={page}&per_page=" + str(per_page)
         # TODO: src_token support
-        response = self.session.get(api)
+        response = self.session.get(api, timeout=self.api_timeout)
         all_items = []
         if response.status_code != 200:
             print("Repo getting failed: " + response.text)
@@ -179,7 +184,11 @@ class Hub(object):
         """Helper method to get GitLab group ID"""
         url = f"{self.dst_base}/groups"
         headers = {'PRIVATE-TOKEN': self.dst_token}
-        response = self.session.get(url, headers=headers)
+        response = self.session.get(
+            url,
+            headers=headers,
+            timeout=self.api_timeout
+        )
         if response.status_code == 200:
             groups = response.json()
             for group in groups:

--- a/hub-mirror/hubmirror.py
+++ b/hub-mirror/hubmirror.py
@@ -58,6 +58,7 @@ class HubMirror(object):
             clone_style=self.args.clone_style,
             src_account_type=self.args.src_account_type,
             dst_account_type=self.args.dst_account_type,
+            api_timeout=int(self.args.api_timeout),
         )
         src_type, src_account = self.args.src.split('/')
 


### PR DESCRIPTION
 - Added API Timeout Configuration (api_timeout) #124 
 Now users can specify a timeout for API requests (default: 60 seconds)
 
 -  Fixed Repo Existence Check #196 
 Previously, when a repository already existed, the variable result was not set.
 This caused an unbound variable error when skipping repo creation.
