### PR TITLE
feat: support self-hosted GitLab endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ steps:
 - `account_type` 默认为user，源和目的的账户类型，可以设置为org（组织）、user（用户）或者group（组），该参数支持**同类型账户**（即组织到组织，或用户到用户，或组到组）的同步。如果源目的仓库是不同类型，请单独使用`src_account_type`和`dst_account_type`配置。
 - `src_account_type` 默认为`account_type`，源账户类型，可以设置为org（组织）、user（用户）或者group（组）。
 - `dst_account_type` 默认为`account_type`，目的账户类型，可以设置为org（组织）、user（用户）或者group（组）。
+- `src_endpoint` 默认为空，仅在源端为GitLab时生效，用于自托管GitLab地址，例如`gitlab.example.com`（无需包含`https://`前缀），为空时使用`gitlab.com`。
+- `dst_endpoint` 默认为空，仅在目的端为GitLab时生效，用于自托管GitLab地址，例如`gitlab.example.com`（无需包含`https://`前缀），为空时使用`gitlab.com`。
 - `clone_style` 默认为https，可以设置为ssh或者https。当设置为ssh时，你需要将`dst_key`所对应的公钥同时配置到源端和目的端。
 - `cache_path` 默认为'', 将代码缓存在指定目录，用于与actions/cache配合以加速镜像过程。
 - `black_list` 默认为'', 配置后，黑名单中的repos将不会被同步，如“repo1,repo2,repo3”。
@@ -209,6 +211,8 @@ steps:
   with:
     src: github/organization-name
     dst: gitlab/group-name
+    # 自托管GitLab可选
+    # dst_endpoint: gitlab.example.com
     dst_key: ${{ secrets.GITLAB_PRIVATE_KEY }}
     dst_token: ${{ secrets.GITLAB_TOKEN }}
     account_type: group
@@ -238,4 +242,3 @@ steps:
 如果觉得不错，**来个star**支持下作者吧！你的Star是我更新代码的动力！：）
 
 想任何想吐槽或者建议的都可以直接飞个[issue](https://github.com/Yikun/hub-mirror-action/issues).
-

--- a/README_en.md
+++ b/README_en.md
@@ -45,6 +45,8 @@ More than [100+](https://github.com/search?p=2&q=hub-mirror-action+%22account_ty
 - `account_type` (optional) default is `user`, the account type of src and dst account, can be set to `org` or `user`，For GitLab: can be set to `group` or `user`,only support mirror between same account type (that is "org to org" or "user to user" or "group to group"). if u wanna mirror difference account type, use the `src_account_type` and `dst_account_type` please.
 - `src_account_type` (optional) default is `account_type`, the account type of src account, can be set to `org` or `user` or `group`.
 - `dst_account_type` (optional) default is `account_type`, the account type of dst account, can be set to `org` or `user`r `group`.
+- `src_endpoint` (optional) only for self-hosted GitLab source, used for self-hosted GitLab endpoint like `gitlab.example.com` (no https:// prefix), default is empty.
+- `dst_endpoint` (optional) only for self-hosted GitLab destination, used for self-hosted GitLab endpoint like `gitlab.example.com` (no https:// prefix), default is `gitlab.com`.
 - `clone_style` (optional) default is `https`, can be set to `ssh` or `https`.When you are using ssh clone style, you need to configure the public key of `dst_key` to both source end and destination end.
 - `cache_path` (optional) let code clone in specific path, can be used with actions/cache to speed up mirror.
 - `black_list` (optional) the black list, such as “repo1,repo2,repo3”.
@@ -77,6 +79,8 @@ More than [100+](https://github.com/search?p=2&q=hub-mirror-action+%22account_ty
   with:
     src: github/organization-name
     dst: gitlab/group-name
+    # Optional for self-hosted GitLab
+    # dst_endpoint: gitlab.example.com
     dst_key: ${{ secrets.GITLAB_PRIVATE_KEY }}
     dst_token: ${{ secrets.GITLAB_TOKEN }}
     account_type: group

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,15 @@ inputs:
   dst:
     description: "Destination name. Such as `gitee/kunpengcompute`."
     required: true
+  dst_endpoint:
+    description: "Destination endpoint for self-hosted, currently only Gitlab is supported, like gitlab.example.com (no https:// prefix)."
+    default: ''
   src:
     description: "Source name. Such as `github/kunpengcompute`."
     required: true
+  src_endpoint:
+    description: "Source endpoint for self-hosted, currently only Gitlab is supported, like gitlab.example.com (no https:// prefix)."
+    default: ''
   account_type:
     description: "The account type. Such as org, user, group."
     default: 'user'
@@ -66,7 +72,9 @@ runs:
     - ${{ inputs.dst_key }}
     - ${{ inputs.dst_token }}
     - ${{ inputs.src }}
+    - ${{ inputs.src_endpoint }}
     - ${{ inputs.dst }}
+    - ${{ inputs.dst_endpoint }}
     - ${{ inputs.account_type }}
     - ${{ inputs.src_account_type }}
     - ${{ inputs.dst_account_type }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,9 @@ pip3 install -r /hub-mirror/requirements.txt
 git lfs install
 
 python3 /hub-mirror/hubmirror.py --src "${INPUT_SRC}" --dst "${INPUT_DST}" \
+--src-endpoint "${INPUT_SRC_ENDPOINT}" \
 --dst-token "${INPUT_DST_TOKEN}" \
+--dst-endpoint "${INPUT_DST_ENDPOINT}" \
 --account-type "${INPUT_ACCOUNT_TYPE}" \
 --src-account-type "${INPUT_SRC_ACCOUNT_TYPE}" \
 --dst-account-type "${INPUT_DST_ACCOUNT_TYPE}" \

--- a/hub-mirror/hub.py
+++ b/hub-mirror/hub.py
@@ -11,6 +11,8 @@ class Hub(object):
         clone_style="https",
         src_account_type=None,
         dst_account_type=None,
+        src_endpoint="",
+        dst_endpoint="",
         api_timeout=60,
     ):
         self.api_timeout = api_timeout
@@ -27,12 +29,18 @@ class Hub(object):
         )
         self.dst_token = dst_token
         self.session = requests.Session()
+
+        # Note that the host will be refreshed if endpoint is set
+        self.dst_host = self.dst_type + ".com"
+        self.src_host = self.src_type + ".com"
         if self.dst_type == "gitee":
             self.dst_base = 'https://gitee.com/api/v5'
         elif self.dst_type == "github":
             self.dst_base = 'https://api.github.com'
         elif self.dst_type == "gitlab":
-            self.dst_base = 'https://gitlab.com/api/v4'
+            gitlab_host = dst_endpoint or "gitlab.com"
+            self.dst_base = "https://" + gitlab_host + '/api/v4'
+            self.dst_host = gitlab_host
         elif self.dst_type == "gitcode":
             self.dst_base = 'https://api.gitcode.com/api/v5'
 
@@ -45,14 +53,16 @@ class Hub(object):
             self.src_base = 'https://api.github.com'
             self.src_repo_base = prefix + 'github.com' + suffix
         elif self.src_type == "gitlab":
-            self.src_base = 'https://gitlab.com/api/v4'
-            self.src_repo_base = prefix + 'gitlab.com' + suffix
+            gitlab_host = src_endpoint or "gitlab.com"
+            self.src_base = "https://" + gitlab_host + '/api/v4'
+            self.src_host = gitlab_host
+            self.src_repo_base = prefix + gitlab_host + suffix
         elif self.src_type == "gitcode":
             self.src_base = 'https://api.gitcode.com/api/v5'
             self.src_repo_base = prefix + 'gitcode.com' + suffix
         self.src_repo_base = self.src_repo_base + self.src_account
         # TODO: toekn push support
-        prefix = "git@" + self.dst_type + ".com:"
+        prefix = "git@" + self.dst_host + ":"
         self.dst_repo_base = prefix + self.dst_account
 
     def _validate_account_type(self, platform_type, account_type, role):

--- a/hub-mirror/hubmirror.py
+++ b/hub-mirror/hubmirror.py
@@ -58,6 +58,8 @@ class HubMirror(object):
             clone_style=self.args.clone_style,
             src_account_type=self.args.src_account_type,
             dst_account_type=self.args.dst_account_type,
+            src_endpoint=self.args.src_endpoint,
+            dst_endpoint=self.args.dst_endpoint,
             api_timeout=int(self.args.api_timeout),
         )
         src_type, src_account = self.args.src.split('/')


### PR DESCRIPTION
This patch adds support for self-hosted GitLab via introducing `dst_endpoint` and `src_endpoint`.

Linked: #204 