### PR TITLE
Upgrade actions to latest versions for improved security

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -11,9 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/verify-on-ubuntu-org.yml
+++ b/.github/workflows/verify-on-ubuntu-org.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Mirror Github to Gitee
       uses: ./.
       with:

--- a/.github/workflows/verify-on-ubuntu-user-cache.yml
+++ b/.github/workflows/verify-on-ubuntu-user-cache.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Get Time
       id: get-time
@@ -18,7 +18,7 @@ jobs:
       shell: bash
 
     - name: Cache src repos
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache
       with:
         path: ${{ github.workspace }}/hub-mirror-cache

--- a/.github/workflows/verify-on-ubuntu-user.yml
+++ b/.github/workflows/verify-on-ubuntu-user.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source codes
-      uses: actions/checkout@v1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Mirror Github to Gitee with white list
       uses: ./.
       with:

--- a/action.yml
+++ b/action.yml
@@ -73,16 +73,16 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
     - name: Compute uv cache key
       id: uv-cache
-      uses: actions/github-script@v8
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const fs = require('fs');
@@ -100,7 +100,7 @@ runs:
           }
           core.setOutput('uv_cache_key', hash.digest('hex'));
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/uv
         key: ${{ runner.os }}-uv-${{ steps.uv-cache.outputs.uv_cache_key }}


### PR DESCRIPTION
Closes #219

通过 Commit Hash 引用第三方 Actions 基于 [GitHub 的安全实践参考](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions): Pin actions to a full-length commit SHA